### PR TITLE
Fixing implicit instantiation errors with newer libc++ on macOS

### DIFF
--- a/Release/include/cpprest/streams.h
+++ b/Release/include/cpprest/streams.h
@@ -76,16 +76,20 @@ template<>
 struct Value2StringFormatter<uint8_t>
 {
     template<typename T>
-    static std::basic_string<uint8_t> format(const T& val)
+    static std::vector<uint8_t> format(const T& val)
     {
-        std::basic_ostringstream<char> ss;
+        std::ostringstream ss;
         ss << val;
-        return reinterpret_cast<const uint8_t*>(ss.str().c_str());
+        std::string s = ss.str();
+
+        return std::vector<uint8_t>(reinterpret_cast<const uint8_t*>(s.data()),
+                                    reinterpret_cast<const uint8_t*>(s.data()) + s.size());
     }
 
-    static std::basic_string<uint8_t> format(const utf16string& val)
+    static std::vector<uint8_t> format(const utf16string& val)
     {
-        return format(utility::conversions::utf16_to_utf8(val));
+        std::string utf8 = utility::conversions::utf16_to_utf8(val);
+        return format(utf8);
     }
 };
 


### PR DESCRIPTION
Addresses https://github.com/TechSmith/TSCLicensing/issues/1450

cpprestsdk started causing build failures with newer versions of libc++ on macOS. The errors looked like this

![image](https://github.com/user-attachments/assets/5c5968f4-0bc9-4c35-b133-0db9824d1d33)

There was another PR to address this issue in the main cpprestsdk repo, but it may not be the best way to fix the problem. It also is unlikely to get merged any time soon.

https://github.com/microsoft/cpprestsdk/pull/1820

We instead made our own fork of cpprestsdk (this repo) and are making our own change to fix the problem. The modified code is only used by cpprestsdk tests. I was unable to get cpprestsdk to build on its own, including its tests, so I have not been able to fix any new compilation issues that would come up there. Since we don't care about the tests at all, is it worth doing more work there to get it building?

More detail can be found in the PR that integrates these changes.

https://github.com/TechSmith/CommonCpp/pull/5836